### PR TITLE
fix(provider): add extra check before accessing configs

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,7 +75,7 @@ const getServerUrl = (userId, cb) => {
   getProvider(userId, (err, provider) => {
     getUserLocale(userId, (err, locale) => {
 
-      if (provider && provider != '' && locale && locale != '') {
+      if (provider && provider != '' && config.has(provider)  && locale && locale != '') {
         return cb(config.get(provider + '.servers.' + locale), provider);
       } else {
         return cb(null);


### PR DESCRIPTION
Prevents from accessing a non-existent provider config, such as 'webspeech'.